### PR TITLE
Refuse to serve out dotfiles

### DIFF
--- a/src/make_app.ts
+++ b/src/make_app.ts
@@ -49,7 +49,14 @@ export function makeApp(options: AppOptions): PolyserveApplication {
   app.get('*', function (req, res) {
     // Serve local files from . and other components from bower_components
     let url = parseUrl(req.url, true);
-    let splitPath = url.pathname.split('/').slice(1);
+    const pathPieces = url.pathname.split('/');
+    // Don't serve out any dot files.
+    if (pathPieces.some((piece) => piece.startsWith('.'))) {
+      res.status(404);
+      res.send("Not Found");
+      return;
+    }
+    let splitPath = pathPieces.slice(1);
 
     if (splitPath[0] === packageName) {
       if (root) {

--- a/src/make_app.ts
+++ b/src/make_app.ts
@@ -49,7 +49,7 @@ export function makeApp(options: AppOptions): PolyserveApplication {
   app.get('*', function (req, res) {
     // Serve local files from . and other components from bower_components
     let url = parseUrl(req.url, true);
-    const pathPieces = url.pathname.split('/');
+    let pathPieces = url.pathname.split('/');
     // Don't serve out any dot files.
     if (pathPieces.some((piece) => piece.startsWith('.'))) {
       res.status(404);

--- a/test/.dotfile
+++ b/test/.dotfile
@@ -1,0 +1,1 @@
+This should not be served out at http://localhost:8080/components/polyserve-test/.dotfile

--- a/test/.dotfiles-test-folder/index.html
+++ b/test/.dotfiles-test-folder/index.html
@@ -1,0 +1,1 @@
+This should not be served out at http://localhost:8080/components/polyserve-test/.dotfile

--- a/test/start_server_test.js
+++ b/test/start_server_test.js
@@ -61,4 +61,15 @@ suite('startServer', () => {
       .end(done);
   });
 
+  test('does not serve any dotfiles', (done) => {
+    let app = getApp({
+      root: __dirname,
+    });
+    supertest(app)
+      .get('/.dotfiles-test-folder/index.html')
+      .expect(404)
+      .end(done);
+  });
+
+
 });


### PR DESCRIPTION
Prevents stuff like accidentally serving out `.git`
