### PR TITLE
Implement websocket connection to implement live reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Added `-u`/`--component-url` option to support expressing different url to
   fetch components from than `components`.
+* Added `--live-reload-path` option to automatically reload webpages during development.
 
 ### Fixed
 * When no port is given, do a better job of finding an available port.

--- a/custom_typings/ws.d.ts
+++ b/custom_typings/ws.d.ts
@@ -1,0 +1,23 @@
+declare module 'ws' {
+  import * as http from 'spdy';
+  interface WebSocketServerOptions {
+    server: http.Server;
+    clientTracking: boolean;
+  }
+  export class Server {
+    constructor(options: WebSocketServerOptions)
+    clients: WebSocket[];
+    on(event: 'connection', cb: (client: WebSocket) => void): this;
+    close(cb?: () => void): this;
+  }
+  export class WebSocket {
+    constructor(address: string)
+    status: number;
+    message: string;
+    send(data: any, cb?: (err: Error) => void): void;
+    on(event: 'message', cb: (data: any, flags: {}) => any): void;
+    on(event: 'close', cb: () => any): void;
+  }
+
+  export default WebSocket;
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/express": "^4.0.33",
     "@types/mime": "0.0.29",
     "@types/mz": "0.0.29",
-    "@types/node": "^4.0.30",
+    "@types/node": "=4.0.30",
     "@types/opn": "^3.0.28",
     "@types/parse5": "^2.2.34",
     "@types/pem": "^1.8.1",
@@ -54,6 +54,7 @@
     "babel-plugin-transform-es2015-typeof-symbol": "^6.18.0",
     "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
     "babel-plugin-transform-regenerator": "^6.16.1",
+    "chokidar": "^1.6.1",
     "command-line-args": "^3.0.1",
     "command-line-usage": "^3.0.3",
     "content-type": "^1.0.2",
@@ -70,13 +71,15 @@
     "resolve": "^1.0.0",
     "send": "^0.14.1",
     "spdy": "^3.3.3",
-    "ua-parser-js": "^0.7.12"
+    "ua-parser-js": "^0.7.12",
+    "ws": "^1.1.1"
   },
   "devDependencies": {
     "@types/assert": "0.0.29",
     "@types/chai": "^3.4.34",
     "@types/chai-as-promised": "0.0.29",
     "@types/lru-cache": "^2.5.32",
+    "@types/chokidar": "^1.4.31",
     "@types/mocha": "^2.2.33",
     "@types/sinon": "^1.16.31",
     "@types/supertest": "^1.1.31",

--- a/src/args.ts
+++ b/src/args.ts
@@ -139,4 +139,9 @@ export let args: ArgDescriptor[] = [
         'Host URL to proxy to, for example `https://myredirect:8080/foo`',
     type: String,
   },
+  {
+    name: 'live-reload-path',
+    description: 'The file path to watch for changes to automatically reload connected browsers.',
+    type: String,
+  },
 ];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,6 +64,7 @@ export async function run(): Promise<StartServerResult> {
     certPath: cliOptions['cert'],
     pushManifestPath: cliOptions['manifest'],
     proxy: proxyArgs.path && proxyArgs.target && proxyArgs,
+    liveReloadPath: cliOptions['live-reload-path'],
   };
 
   if (cliOptions.help) {

--- a/src/test/live-reload_test.ts
+++ b/src/test/live-reload_test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import * as fs from 'mz/fs';
+import * as path from 'path';
+import * as http from 'spdy';
+
+import {startServer} from '../start_server';
+
+const WebSocket = require('ws');
+
+const root = path.join(__dirname, '..', '..', 'test');
+
+suite('live-reload-middleware', () => {
+
+  let app: http.Server;
+
+  const changedFilePath = path.join(root, 'bower_components', 'change-file.txt');
+
+  setup(async () => {
+    fs.writeFileSync(changedFilePath, 'Original content');
+    app = await startServer({
+      root: root,
+      liveReloadPath: path.join(root, 'bower_components/')
+    });
+  });
+
+  teardown(async () => {
+    fs.unlink(changedFilePath);
+    await app.close();
+  });
+
+  test('sends websocket message when file changes', (done) => {
+    const address = app.address();
+    const ws = new WebSocket(`ws://${address.address}:${address.port}`);
+    ws.on('message', () => {
+      done();
+    });
+    // Timeout to correctly trigger the change event for chokidar.
+    setTimeout(() => {
+      fs.writeFileSync(changedFilePath, 'Changed content');
+    }, 100);
+  });
+
+});

--- a/static/auto-reload.html
+++ b/static/auto-reload.html
@@ -1,0 +1,20 @@
+<!-- @license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at
+http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at
+http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at
+http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at
+http://polymer.github.io/PATENTS.txt -->
+
+<script>
+if (!window.__liveReloadSocket && window.WebSocket) {
+  window.__liveReloadSocket = new WebSocket("ws://" + window.location.hostname + ":" + window.location.port);
+  window.__liveReloadSocket.onmessage = function() {
+    window.location.reload();
+  };
+}
+</script>

--- a/static/index.html
+++ b/static/index.html
@@ -2,6 +2,7 @@
 
 <head>
   <title>Polyserve</title>
+  <link rel="import" href="/_polyserve/live-reload.html">
   <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono"
     rel="stylesheet">
   <style>
@@ -9,16 +10,16 @@
       margin: 40px;
       font-family: 'Roboto', sans-serif;
     }
-    
+
     ul {
       padding-top: 8px;
       padding-bottom: 20px;
     }
-    
+
     li {
       padding-bottom: 8px;
     }
-    
+
     a {
       font-family: 'Roboto Mono', monospace;
     }


### PR DESCRIPTION
This PR implements live-reload with Websockets. It uses `chokidar` to watch for files and `ws` to construct the server-side websocket. A request to `host:port/live-reload.js` will install a simple websocket which listens to any message of the server. The server will send a message when a file was changed in the `live-reload-path`.

You can test this branch with `./bin/polyserve static/ --live-reload-path src/`. Open a browser on the one side of your window and a text editor on the other side. Load `localhost:8080` in the browser and modify a file in the `src` folder of `polyserve`. You can see that the page has reloaded.



Before I did too much work, I wanted to know if you approve this implementation. If you do, I can easily add tests and possibly additional work.

One thing I was wondering about: could we inject the client-side js (essentially a one-liner) by modifying `index.html` with `dom5`. Just like the files are transformed with `babel` compilation. This would remove the special `/live-reload.js` handler, but probably requires some work to make the transformation work.

 - [x] CHANGELOG.md has been updated
 - [x] Write tests

Fixes #26
Fixes #86 
Fixes https://github.com/Polymer/polymer-cli/issues/230

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/polymerlabs/polyserve/135)
<!-- Reviewable:end -->
