### PR TITLE
Update Travis badge for new repository location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # polyserve
 
-[![Build Status](https://travis-ci.org/PolymerLabs/polyserve.svg?branch=master)](https://travis-ci.org/PolymerLabs/polyserve)
+[![Build Status](https://travis-ci.org/Polymer/polyserve.svg?branch=master)](https://travis-ci.org/Polymer/polyserve)
 
 A simple development server for web projects.
 


### PR DESCRIPTION
The repository has moved from `polymerlabs` organisation to `polymer`, which also requires the Travis badge to be updated to this location.

 - [x] CHANGELOG.md has not been updated, no functional change
