### PR TITLE
Require ES5 compilation for Edge < 40.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * When directory paths don't end in `/`, redirect to the right path, not a
   filesystem path. https://github.com/Polymer/polyserve/issues/96
+* Require ES5 compilation for Edge < 40 (fixes #161).
 
 ## [0.16.0](https://github.com/PolymerLabs/polyserve/tree/v0.16.0) (2017-02-14)
 

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -149,7 +149,7 @@ function needCompilation(uaParser: UAParser): boolean {
   const supportsES2015 = (browser.name === 'Chrome' && majorVersion >= 49) ||
       (browser.name === 'Chromium' && majorVersion >= 49) ||
       (browser.name === 'Safari' && majorVersion >= 10) ||
-      (browser.name === 'Edge' && majorVersion >= 14) ||
+      (browser.name === 'Edge' && majorVersion >= 40) ||
       (browser.name === 'Firefox' && majorVersion >= 51);
   return !supportsES2015;
 }


### PR DESCRIPTION
Fixes #161. Versions before 40 have a JIT bug where a constructor can
return the class instead of an instance.

See https://github.com/Microsoft/ChakraCore/issues/1496 and
https://github.com/Microsoft/ChakraCore/issues/2532/.

Tested with http://jsfiddle.net/0k59gbL8/5/. Fails on 38, passes on 40.

 - [x] CHANGELOG.md has been updated
