### PR TITLE
Check Edge versions correctly in compilation switch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * When directory paths don't end in `/`, redirect to the right path, not a
   filesystem path. https://github.com/Polymer/polyserve/issues/96
+* Require ES5 compilation for Edge < 40 (fixes #161).
 
 ## [0.16.0](https://github.com/PolymerLabs/polyserve/tree/v0.16.0) (2017-02-14)
 

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -149,7 +149,7 @@ function needCompilation(uaParser: UAParser): boolean {
   const supportsES2015 = (browser.name === 'Chrome' && majorVersion >= 49) ||
       (browser.name === 'Chromium' && majorVersion >= 49) ||
       (browser.name === 'Safari' && majorVersion >= 10) ||
-      (browser.name === 'Edge' && majorVersion >= 14) ||
+      (browser.name === 'Edge' && majorVersion >= 40) ||
       (browser.name === 'Firefox' && majorVersion >= 51);
   return !supportsES2015;
 }

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -143,16 +143,20 @@ const isInlineJavaScript = dom5.predicates.AND(
 
 export function needCompilation(userAgent: string): boolean {
   const browser = new UAParser(userAgent).getBrowser();
-  const versionSplit = browser.version && browser.version.split('.');
-  const majorVersion = versionSplit ? parseInt(versionSplit[0], 10) : -1;
-  const minorVersion = versionSplit && versionSplit.length > 1 ?
-      parseInt(versionSplit[1], 10) :
-      -1;
+  const versionSplit = (browser.version || '').split('.');
+  const [majorVersion, minorVersion] =
+      versionSplit.map((v) => v ? parseInt(v, 10) : -1);
 
   const supportsES2015 = (browser.name === 'Chrome' && majorVersion >= 49) ||
       (browser.name === 'Chromium' && majorVersion >= 49) ||
       (browser.name === 'OPR' && majorVersion >= 36) ||
       (browser.name === 'Safari' && majorVersion >= 10) ||
+      // Note: The Edge user agent uses the EdgeHTML version, not the main
+      // release version (e.g. EdgeHTML 15 corresponds to Edge 40). See
+      // https://en.wikipedia.org/wiki/Microsoft_Edge#Release_history.
+      //
+      // Versions before 15.15063 may contain a JIT bug affecting ES6
+      // constructors (see #161).
       (browser.name === 'Edge' &&
        (majorVersion > 15 || (majorVersion === 15 && minorVersion >= 15063))) ||
       (browser.name === 'Firefox' && majorVersion >= 51);

--- a/src/test/compile-middleware_test.ts
+++ b/src/test/compile-middleware_test.ts
@@ -111,26 +111,30 @@ suite('compile-middleware', () => {
   });
 
   test('needCompilation', () => {
-    const cases: [string, boolean][] = [
-      [
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/14.99999',
-        true,
-      ],
-      [
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.14986',
-        true,
-      ],
-      [
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
-        false,
-      ],
-      [
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/16.00000',
-        false,
-      ],
+    const cases: {userAgent: string, expected: boolean}[] = [
+      {
+        userAgent:
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/14.99999',
+        expected: true,
+      },
+      {
+        userAgent:
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.14986',
+        expected: true,
+      },
+      {
+        userAgent:
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
+        expected: false,
+      },
+      {
+        userAgent:
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/16.00000',
+        expected: false,
+      },
     ];
-    for (const [userAgent, expected] of cases) {
-      assert.equal(needCompilation(userAgent), expected, userAgent);
+    for (const c of cases) {
+      assert.equal(needCompilation(c.userAgent), c.expected, c.userAgent);
     }
   });
 });

--- a/src/test/compile-middleware_test.ts
+++ b/src/test/compile-middleware_test.ts
@@ -111,30 +111,30 @@ suite('compile-middleware', () => {
   });
 
   test('needCompilation', () => {
-    const cases: {userAgent: string, expected: boolean}[] = [
-      {
-        userAgent:
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/14.99999',
-        expected: true,
-      },
-      {
-        userAgent:
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.14986',
-        expected: true,
-      },
-      {
-        userAgent:
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
-        expected: false,
-      },
-      {
-        userAgent:
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/16.00000',
-        expected: false,
-      },
+    const cases: [string, boolean][] = [
+      [
+        'unknown browser',
+        true,
+      ],
+      [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/14.99999',
+        true,
+      ],
+      [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.14986',
+        true,
+      ],
+      [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
+        false,
+      ],
+      [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/16.00000',
+        false,
+      ],
     ];
-    for (const c of cases) {
-      assert.equal(needCompilation(c.userAgent), c.expected, c.userAgent);
+    for (const [userAgent, expected] of cases) {
+      assert.equal(needCompilation(userAgent), expected, userAgent);
     }
   });
 });

--- a/src/test/compile-middleware_test.ts
+++ b/src/test/compile-middleware_test.ts
@@ -17,7 +17,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as supertest from 'supertest-as-promised';
-import {babelCompileCache} from '../compile-middleware';
+import {babelCompileCache, needCompilation} from '../compile-middleware';
 import {getApp} from '../start_server';
 
 chai.use(chaiAsPromised);
@@ -108,5 +108,29 @@ suite('compile-middleware', () => {
       // The valid script tag should still be compiled.
       assert.notInclude(response.text, `<script>\nclass A {}\n</script>`);
     });
+  });
+
+  test('needCompilation', () => {
+    const cases: [string, boolean][] = [
+      [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/14.99999',
+        true,
+      ],
+      [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.14986',
+        true,
+      ],
+      [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063',
+        false,
+      ],
+      [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/16.00000',
+        false,
+      ],
+    ];
+    for (const [userAgent, expected] of cases) {
+      assert.equal(needCompilation(userAgent), expected, userAgent);
+    }
   });
 });


### PR DESCRIPTION
Really fixes #161. This time for real! My previous PR #173 assumed that
the Edge user agent used the main browser release version. Actually it
uses the EdgeHTML version. The fix we care about for the original issue
is in a major release of Edge, but a minor release of EdgeHTML, so we
have to check minor version now too.

https://en.wikipedia.org/wiki/Microsoft_Edge#Release_history

Also added a test and a small refactor so that we can paste real user
agent strings.

 - [x] CHANGELOG.md already updated in #173 
