### PR TITLE
More clang-format.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "npm run build && mocha && tslint \"src/**/*.ts\"",
     "test:watch": "watchy -w src/ -- npm test",
     "prepublish": "npm run build",
-    "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i"
+    "format": "find src test -iname '*.ts' | xargs clang-format --style=file -i"
   },
   "keywords": [
     "polymer",
@@ -84,7 +84,7 @@
     "@types/tmp": "0.0.31",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "clang-format": "=1.0.45",
+    "clang-format": "=1.0.48",
     "intercept-stdout": "^0.1.2",
     "mocha": "^3.1.0",
     "sinon": "^1.17.5",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,8 +86,7 @@ export async function run(): Promise<StartServerResult> {
     const mainlineServer = serverInfos;
     const urls = getServerUrls(options, mainlineServer.server);
     console.log(`Files in this directory are available under the following URLs
-    applications: ${
-                  url.format(urls.serverUrl)}
+    applications: ${url.format(urls.serverUrl)}
     reusable components: ${url.format(urls.componentUrl)}
   `);
   } else {

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -85,7 +85,7 @@ export function babelCompile(forceCompile: boolean): RequestHandler {
           compileMimeTypes.indexOf(getContentType(response)) >= 0;
     },
 
-    transform(request: Request, response: Response, body: string): string /**/ {
+    transform(request: Request, response: Response, body: string): string {
       const contentType = getContentType(response);
       const compile =
           forceCompile || needCompilation(request.headers['user-agent']);

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -326,7 +326,9 @@ export function getApp(options: ServerOptions): express.Express {
     for (let char of ['*', '?', '+']) {
       if (escapedPath.indexOf(char) > -1) {
         console.warn(
-            `Proxy path includes character "${char}" which can cause problems during route matching.`);
+            `Proxy path includes character "${
+                                              char
+                                            }" which can cause problems during route matching.`);
       }
     }
 

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -326,9 +326,8 @@ export function getApp(options: ServerOptions): express.Express {
     for (let char of ['*', '?', '+']) {
       if (escapedPath.indexOf(char) > -1) {
         console.warn(
-            `Proxy path includes character "${
-                                              char
-                                            }" which can cause problems during route matching.`);
+            `Proxy path includes character "${char}"` +
+            `which can cause problems during route matching.`);
       }
     }
 

--- a/src/util/open_browser.ts
+++ b/src/util/open_browser.ts
@@ -27,9 +27,10 @@ function openWebPage(url: string, withBrowser?: string) {
   opn(url, openOptions, (err) => {
     if (err) {
       // log error and continue
-      console.error(
-          `ERROR: Problem launching "${openOptions.app || 'default web browser'
-                                                          }".`);
+      console.error(`ERROR: Problem launching "${
+                                                 openOptions.app ||
+                                                 'default web browser'
+                                               }".`);
     }
   });
 }

--- a/src/util/open_browser.ts
+++ b/src/util/open_browser.ts
@@ -27,10 +27,9 @@ function openWebPage(url: string, withBrowser?: string) {
   opn(url, openOptions, (err) => {
     if (err) {
       // log error and continue
-      console.error(`ERROR: Problem launching "${
-                                                 openOptions.app ||
-                                                 'default web browser'
-                                               }".`);
+      console.error(
+          `ERROR: Problem launching ` +
+          `"${openOptions.app || 'default web browser'}".`);
     }
   });
 }


### PR DESCRIPTION
- Bump clang-format to 1.0.48.
- Fix find command in npm format script, which wasn't properly catching .js files (but didn't need to).
- Format everything.
- [x] CHANGELOG.md does not need updating
