### PR TITLE
Ability for polyserve to serve entry points other than index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   point). This adapter is needed when serving ES5 to browsers that support the
   native Custom Elements API
   ([#164](https://github.com/Polymer/polyserve/issues/164)).
+* A server can now be started with a custom entry point; previously index.html
+  was always assumed ([#161](https://github.com/Polymer/polyserve/issues/161)).
 
 ## [0.17.0](https://github.com/PolymerLabs/polyserve/tree/v0.17.0) (2017-04-13)
 

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -16,7 +16,7 @@ import * as assert from 'assert';
 import * as express from 'express';
 import * as fs from 'mz/fs';
 import * as path from 'path';
-import {urlFromPath} from 'polymer-build';
+import {urlFromPath} from 'polymer-build/lib/path-transformers';
 import * as send from 'send';
 // TODO: Switch to node-http2 when compatible with express
 // https://github.com/molnarg/node-http2/issues/100

--- a/src/start_server.ts
+++ b/src/start_server.ts
@@ -16,6 +16,7 @@ import * as assert from 'assert';
 import * as express from 'express';
 import * as fs from 'mz/fs';
 import * as path from 'path';
+import {urlFromPath} from 'polymer-build';
 import * as send from 'send';
 // TODO: Switch to node-http2 when compatible with express
 // https://github.com/molnarg/node-http2/issues/100
@@ -35,6 +36,13 @@ const httpProxy = require('http-proxy-middleware');
 export interface ServerOptions {
   /** The root directory to serve **/
   root?: string;
+
+  /**
+   * The path on disk of the entry point HTML file that will be served for
+   * app-shell style projects. Must be contained by `root`. Defaults to
+   * `index.html`.
+   */
+  entrypoint?: string;
 
   /** Whether or not to compile JavaScript **/
   compile?: 'always'|'never'|'auto';
@@ -356,14 +364,21 @@ export function getApp(options: ServerOptions): express.Express {
 
   app.use(`/${componentUrl}/`, polyserve);
 
+  // `send` expects files to be specified relative to the given root and as a
+  // URL rather than a file system path.
+  const entrypoint =
+      options.entrypoint ? urlFromPath(root, options.entrypoint) : 'index.html';
+
   app.get('/*', (req, res) => {
     pushResources(options, req, res);
     const filePath = req.path;
-    send(req, filePath, {root: root})
+    send(req, filePath, {root: root, index: entrypoint})
         .on('error',
             (error: send.SendError) => {
               if ((error).status === 404 && !filePathRegex.test(filePath)) {
-                send(req, '/', {root: root}).pipe(res);
+                // The static file handling middleware failed to find a file on
+                // disk. Serve the entry point HTML file instead of a 404.
+                send(req, entrypoint, {root: root}).pipe(res);
               } else {
                 res.statusCode = error.status || 500;
                 res.end(error.message);

--- a/src/test/start_server_test.ts
+++ b/src/test/start_server_test.ts
@@ -13,6 +13,7 @@
  */
 
 import * as chai from 'chai';
+import {expect} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as fs from 'mz/fs';
 import * as path from 'path';
@@ -62,12 +63,30 @@ suite('startServer', () => {
   });
 
 
-  test('serves index.html, not 404', async() => {
+  test('serves default entry point index.html instead of 404', async() => {
     const app = getApp({root});
     await supertest(app).get('/foo').expect(200).expect((res: any) => {
-      if (!res.text.includes('INDEX')) {
-        throw new Error('Expected body to contain INDEX');
-      }
+      expect(res.text).to.have.string('INDEX');
+    });
+  });
+
+  test('serves custom entry point from "/"', async() => {
+    const app = getApp({
+      root,
+      entrypoint: path.join(root, 'custom-entry.html'),
+    });
+    await supertest(app).get('/').expect(200).expect((res: any) => {
+      expect(res.text).to.have.string('CUSTOM-ENTRY');
+    });
+  });
+
+  test('serves custom entry point instead of 404', async() => {
+    const app = getApp({
+      root,
+      entrypoint: path.join(root, 'custom-entry.html'),
+    });
+    await supertest(app).get('/not/a/file').expect(200).expect((res: any) => {
+      expect(res.text).to.have.string('CUSTOM-ENTRY');
     });
   });
 
@@ -236,9 +255,7 @@ suite('startServer', () => {
           .get('/api/v1/')
           .expect(200)
           .expect((res: any) => {
-            if (!res.text.includes('INDEX')) {
-              throw new Error('Expected body to contain INDEX');
-            }
+            expect(res.text).to.have.string('INDEX');
           });
     });
   });

--- a/test/custom-entry.html
+++ b/test/custom-entry.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+    <title>CUSTOM-ENTRY</title>
+    <script src="webcomponents-loader.js"></script>
+  </head>
+</html>


### PR DESCRIPTION
- Part of #180.
- Note that it won't be possible to use the feature unless you are calling via polymer-cli.
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
