### PR TITLE
Updated CHANGELOG for the 0.20.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.20.0](https://github.com/PolymerLabs/polyserve/tree/v0.20.0) (2017-08-08)
+
 * Update Polymer Build to v2.0.0
 * Allow package names to include a '/'
-* Added --npm flag which sets component folder to node_modules and reads package
-  name from package.json.
+* Added --npm flag which sets component folder to node_modules and reads package name from package.json.
 
 ## [0.19.1](https://github.com/PolymerLabs/polyserve/tree/v0.19.1) (2017-05-22)
 


### PR DESCRIPTION
 * Update Polymer Build to v2.0.0
 * Allow package names to include a '/'
 * Added --npm flag which sets component folder to node_modules and reads package name from package.json.
 * [x] CHANGELOG.md has been updated
