### PR TITLE
Don't inject ES5 adapter for browsers that support ES2015 but not modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Auto-compile now includes transformation of ES modules to AMD modules with RequireJS for browsers that do not support ES modules. Includes special handling for WCT.
+* Fix #48 where we would incorrectly inject the ES5 adapter for browsers that supported ES2015 but not modules.
 
 ## [0.20.0](https://github.com/PolymerLabs/polyserve/tree/v0.20.0) (2017-08-08)
 

--- a/src/custom-elements-es5-adapter-middleware.ts
+++ b/src/custom-elements-es5-adapter-middleware.ts
@@ -12,11 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {browserCapabilities} from 'browser-capabilities';
 import {parse as parseContentType} from 'content-type';
 import {Request, RequestHandler, Response} from 'express';
 import {addCustomElementsEs5Adapter} from 'polymer-build';
 
-import {browserNeedsCompilation} from './compile-middleware';
 import {transformResponse} from './transform-middleware';
 
 /**
@@ -35,7 +35,8 @@ export function injectCustomElementsEs5Adapter(forceCompile: boolean):
           contentTypeHeader && parseContentType(contentTypeHeader).type;
       // We only need to inject the adapter if we are compiling to ES5.
       return contentType === 'text/html' &&
-          (forceCompile || browserNeedsCompilation(request.get('user-agent')));
+          (forceCompile ||
+           !browserCapabilities(request.get('user-agent')).has('es2015'));
     },
 
     transform(_request: Request, _response: Response, body: string): string {

--- a/src/test/compile-middleware_test.ts
+++ b/src/test/compile-middleware_test.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as supertest from 'supertest';
 
-import {babelCompileCache, browserNeedsCompilation, isPolyfill} from '../compile-middleware';
+import {babelCompileCache, isPolyfill} from '../compile-middleware';
 import {getApp} from '../start_server';
 
 chai.use(chaiAsPromised);
@@ -167,15 +167,6 @@ suite('compile-middleware', () => {
         }
       });
     });
-  });
-
-  test('browserNeedsCompilation', () => {
-    for (const userAgent of userAgentsThatDontSupportES2015OrModules) {
-      assert.equal(browserNeedsCompilation(userAgent), true, userAgent);
-    }
-    for (const userAgent of userAgentsThatSupportES2015AndModules) {
-      assert.equal(browserNeedsCompilation(userAgent), false, userAgent);
-    }
   });
 
   test('isPolyfill', () => {

--- a/src/test/custom-elements-es5-adapter-middleware_test.ts
+++ b/src/test/custom-elements-es5-adapter-middleware_test.ts
@@ -22,24 +22,47 @@ const adapterScriptName = 'custom-elements-es5-adapter.js';
 
 suite('custom-elements-es5-adapter-middleware', () => {
 
-  let app: Express.Application;
-
-  beforeEach(() => {
-    app = getApp({root, compile: 'always'});
-  });
-
   test('injects into entry point', async () => {
+    const app = getApp({root, compile: 'always'});
     await supertest(app).get('/').expect(200).expect((res: any) => {
       expect(res.text).to.have.string(adapterScriptName);
     });
   });
 
   test('does not inject into non entry point', async () => {
+    const app = getApp({root, compile: 'always'});
     await supertest(app)
         .get('/components/test-component/test.html')
         .expect(200)
         .expect((res: any) => {
-          expect(res.text).to.not.string(adapterScriptName);
+          expect(res.text).to.not.have.string(adapterScriptName);
+        });
+  });
+
+  test('only injects when ES5 compilation is required', async () => {
+    // Chrome 48 doesn't support ES2015.
+    const chrome48 =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.3163.31 Safari/537.36';
+    const app = getApp({root});
+    await supertest(app)
+        .get('/')
+        .set('User-Agent', chrome48)
+        .expect(200)
+        .expect((res: any) => {
+          expect(res.text).to.have.string(adapterScriptName);
+        });
+
+    // Chrome 60 supports ES2015, but not modules. Regression test for
+    // https://github.com/Polymer/polyserve/issues/217 where lack of modules
+    // support would incorrectly cause injection of the ES5 adapter.
+    const chrome60 =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.31 Safari/537.36';
+    await supertest(app)
+        .get('/')
+        .set('User-Agent', chrome60)
+        .expect(200)
+        .expect((res: any) => {
+          expect(res.text).to.not.have.string(adapterScriptName);
         });
   });
 });


### PR DESCRIPTION
Fixes #48.
 - [x] CHANGELOG.md has been updated
