### PR TITLE
Update CHANGELOG for the 0.21.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.21.0](https://github.com/PolymerLabs/polyserve/tree/v0.21.0) (2017-09-13)
+
 * Auto-compile now includes transformation of ES modules to AMD modules with RequireJS for browsers that do not support ES modules. Includes special handling for WCT.
 * Fix #48 where we would incorrectly inject the ES5 adapter for browsers that supported ES2015 but not modules.
 


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
 - Auto-compile now includes transformation of ES modules to AMD modules with RequireJS for browsers that do not support ES modules. Includes special handling for WCT.
 - Fix #48 where we would incorrectly inject the ES5 adapter for browsers that supported ES2015 but not modules.

Ran a sanity check test of WCT on paper-button with this copy of polyserve to ensure no regression.  Results:
```
Windows 10 microsoftedge (22/0/0)
Windows 8.1 IE 11 (22/0/0)
OS X 10.11 safari 10 (22/0/0)
OS X 10.11 safari 9 (22/0/0)
Linux chrome (22/0/0)
Linux firefox (22/0/0)
```
