### PR TITLE
Made the compile middleware aware of wct-browser-legacy/browser.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Identify wct-browser-legacy as a web-component-tester client package, to add a hook for deferring mocha execution in support of requirejs.
+
 ## [0.21.9](https://github.com/PolymerLabs/polyserve/tree/v0.21.9) (2017-09-15)
 
 * Fix issue where requirejs is installed somewhere other than in polyserve's own node_modules subfolder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Identify wct-browser-legacy as a web-component-tester client package, to add a hook for deferring mocha execution in support of requirejs.
+* Change `x(...args)` syntax to `x.apply(undefined, arguments)` to support IE11.
 
 ## [0.21.9](https://github.com/PolymerLabs/polyserve/tree/v0.21.9) (2017-09-15)
 

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -167,7 +167,9 @@ function compileHtml(
     const src = dom5.getAttribute(scriptTag, 'src');
     const isInline = !src;
 
-    if (src && src.includes('web-component-tester/browser.js')) {
+    if (src &&
+        (src.includes('web-component-tester/browser.js') ||
+         src.includes('wct-browser-legacy/browser.js'))) {
       wctScriptTag = scriptTag;
     }
 

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -267,9 +267,9 @@ function compileHtml(
     var moduleCount = 0;
     window.require = function(deps, factory) {
       moduleCount++;
-      originalRequire(deps, function(...args) {
+      originalRequire(deps, function() {
         if (factory) {
-          factory(...args);
+          factory.apply(undefined, arguments);
         }
         moduleCount--;
         if (moduleCount === 0) {

--- a/test/bower_components/test-modules/golden/test-suite-wct.html
+++ b/test/bower_components/test-modules/golden/test-suite-wct.html
@@ -30,9 +30,9 @@
     var moduleCount = 0;
     window.require = function(deps, factory) {
       moduleCount++;
-      originalRequire(deps, function(...args) {
+      originalRequire(deps, function() {
         if (factory) {
-          factory(...args);
+          factory.apply(undefined, arguments);
         }
         moduleCount--;
         if (moduleCount === 0) {


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - This fix makes running tests possible when suites are inside modules and you're using wct with npm and your browser doesn't know what modules are.