### PR TITLE
Do not compile modules when nomodule script exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Fix issue with module scripts being compiled when a nomodule script exists.
+
 ## [0.22.1](https://github.com/PolymerLabs/polyserve/tree/v0.22.1) (2017-09-19)
 
 * Fixes issue with the babel compile cache where different compilation options were using the same namespace. ([#216](https://github.com/Polymer/polyserve/issues/216)).

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -145,6 +145,9 @@ function compileHtml(
 
   const jsNodes = dom5.queryAll(document, isJsScriptNode);
 
+  // Assume that if this document has a nomodule script, the author is already
+  // handling browsers that don't support modules, and we don't need to
+  // transform anything.
   if (jsNodes.find((node) => dom5.hasAttribute(node, 'nomodule'))) {
     return source;
   }

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -143,7 +143,13 @@ function compileHtml(
   const document = parse5.parse(source);
   let requireScriptTag, wctScriptTag;
 
-  for (const scriptTag of dom5.queryAll(document, isJsScriptNode)) {
+  const jsNodes = dom5.queryAll(document, isJsScriptNode);
+
+  if (jsNodes.find((node) => dom5.hasAttribute(node, 'nomodule'))) {
+    return source;
+  }
+
+  for (const scriptTag of jsNodes) {
     // Is this a module script we should transform?
     const transformingModule = options.transformModules &&
         dom5.getAttribute(scriptTag, 'type') === 'module';

--- a/src/test/compile-middleware_test.ts
+++ b/src/test/compile-middleware_test.ts
@@ -224,6 +224,10 @@ suite('compile-middleware', () => {
       await assertGolden('test-suite-no-wct.html');
     });
 
+    test('does not transform HTML when nomodule script exists', async () => {
+      await assertGolden('test-suite-nomodule.html');
+    });
+
     test('transforms module-looking JS', async () => {
       await assertGolden('lib-module.js');
     });

--- a/test/bower_components/test-modules/golden/test-suite-nomodule.html
+++ b/test/bower_components/test-modules/golden/test-suite-nomodule.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+
+<body>
+  <script type="module">
+    import {myFunc} from 'lib.js';
+  </script>
+
+  <script nomodule>
+    const foo = 'bar';
+  </script>
+</body>
+
+</html>

--- a/test/bower_components/test-modules/test-suite-nomodule.html
+++ b/test/bower_components/test-modules/test-suite-nomodule.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+
+<body>
+  <script type="module">
+    import {myFunc} from 'lib.js';
+  </script>
+
+  <script nomodule>
+    const foo = 'bar';
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
If a `<script nomodule>` exists in the file, do not transform modules. This prevents double instantiation of objects when both the compiled script and the non-compiled script are run.

 - [x] CHANGELOG.md has been updated

Fixes #226