### PR TITLE
Support express app modification/substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Added ability to modify and/or substitute generated express apps for when calling startServers, to support more flexibility in request handler ordering and middleware scenarios.
 * Fix issue with module scripts being compiled when a nomodule script exists.
 
 ## [0.22.1](https://github.com/PolymerLabs/polyserve/tree/v0.22.1) (2017-09-19)

--- a/src/test/start_server_test.ts
+++ b/src/test/start_server_test.ts
@@ -519,7 +519,7 @@ suite('startServer', () => {
 });
 
 suite('startServers', () => {
-  suite('remap', () => {
+  suite('replace generated app with optional appMapper argument', () => {
 
     let prevCwd: string;
     setup(() => {

--- a/src/test/start_server_test.ts
+++ b/src/test/start_server_test.ts
@@ -15,6 +15,7 @@
 import * as chai from 'chai';
 import {expect} from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import * as express from 'express';
 import * as fs from 'mz/fs';
 import * as path from 'path';
 import * as pem from 'pem';
@@ -24,7 +25,7 @@ import * as supertest from 'supertest';
 import * as tmp from 'tmp';
 
 import {getApp, ServerOptions} from '../start_server';
-import {startServer, startServers} from '../start_server';
+import {MainlineServer, startServer, startServers} from '../start_server';
 
 
 chai.use(chaiAsPromised);
@@ -518,6 +519,36 @@ suite('startServer', () => {
 });
 
 suite('startServers', () => {
+  suite('remap', () => {
+
+    let prevCwd: string;
+    setup(() => {
+      prevCwd = process.cwd();
+      process.chdir(root);
+    });
+
+    teardown(() => {
+      process.chdir(prevCwd);
+    });
+
+    test('allows replacing app with parent app', async () => {
+      const server = <MainlineServer>await startServers(
+          {}, async (app: express.Express) => {
+            const newApp = express();
+            newApp.use('x', function(_, res) {
+              res.send('x');
+            });
+            newApp.use('*', app);
+            return newApp;
+          });
+
+      assert.equal(server.kind, 'mainline');
+
+      supertest(server.server).get('/x').expect(200, 'have an x\n');
+      supertest(server.server).get('/test-file.txt').expect(200, 'PASS\n');
+    });
+  });
+
   suite('variants', () => {
     const variantsRoot = path.join(root, 'variants');
 


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - Added ability to modify and/or substitute generated express apps for when calling startServers, to support more flexibility in request handler ordering and middleware scenarios.
 - This addresses the needs of users and WCT plugin authors being expressed in this issue: https://github.com/Polymer/polyserve/issues/138
 - An alternative to the approach in this PR would be to split out the way the express apps are created and separating the process of creating all apps for variants etc from the starting-of-them-as-servers, but that would necessitate a larger API change, whereas this hook seemed to provide a convenient means to express arbitrary manipulation at server start time that I think is easy to reason about if needed and easy to ignore otherwise...