### PR TITLE
Allow for relative roots that are resolved to the cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Root directories can now be relative paths
+
 ## [0.23.0](https://github.com/PolymerLabs/polyserve/tree/0.23.0) (2017-10-02)
 
 * Added ability to modify and/or substitute generated express apps for when calling startServers, to support more flexibility in request handler ordering and middleware scenarios.

--- a/src/make_app.ts
+++ b/src/make_app.ts
@@ -14,16 +14,16 @@
 
 import * as express from 'express';
 import * as path from 'path';
-import { parse as parseUrl } from 'url';
+import {parse as parseUrl} from 'url';
 
 import send = require('send');
 
 export interface AppOptions {
   componentDir: string;
   packageName: string;
-  headers?: { [name: string]: string };
+  headers?: {[name: string]: string};
   root?: string;
-  compile?: 'always' | 'never' | 'auto';
+  compile?: 'always'|'never'|'auto';
 }
 
 export interface PolyserveApplication extends express.Express {
@@ -92,25 +92,25 @@ export function makeApp(options: AppOptions): PolyserveApplication {
     // _file_ path plus a leading slash, not the URL. :(
     // https://github.com/pillarjs/send/issues/132
     _send
-      .on('directory',
-      () => {
-        res.statusCode = 301;
-        res.setHeader('Location', req.originalUrl + '/');
-        res.end('Redirecting to ' + req.originalUrl + '/');
-      })
-      .on('error',
-      (err) => {
-        // A RequireJS found in the user's components directory will win
-        // over our verison.
-        if (err.statusCode === 404 &&
-          err.path.endsWith('/requirejs/require.js')) {
-          send(req, localRequirePath).pipe(res);
-        } else {
-          res.statusCode = err.statusCode;
-          res.end(err.Error);
-        }
-      })
-      .pipe(res);
+        .on('directory',
+            () => {
+              res.statusCode = 301;
+              res.setHeader('Location', req.originalUrl + '/');
+              res.end('Redirecting to ' + req.originalUrl + '/');
+            })
+        .on('error',
+            (err) => {
+              // A RequireJS found in the user's components directory will win
+              // over our verison.
+              if (err.statusCode === 404 &&
+                  err.path.endsWith('/requirejs/require.js')) {
+                send(req, localRequirePath).pipe(res);
+              } else {
+                res.statusCode = err.statusCode;
+                res.end(err.Error);
+              }
+            })
+        .pipe(res);
   });
   app.packageName = packageName;
   return app;

--- a/src/make_app.ts
+++ b/src/make_app.ts
@@ -14,16 +14,16 @@
 
 import * as express from 'express';
 import * as path from 'path';
-import {parse as parseUrl} from 'url';
+import { parse as parseUrl } from 'url';
 
 import send = require('send');
 
 export interface AppOptions {
   componentDir: string;
   packageName: string;
-  headers?: {[name: string]: string};
+  headers?: { [name: string]: string };
   root?: string;
-  compile?: 'always'|'never'|'auto';
+  compile?: 'always' | 'never' | 'auto';
 }
 
 export interface PolyserveApplication extends express.Express {
@@ -48,7 +48,7 @@ const localRequirePath = require.resolve('requirejs/require.js');
  * @return {Object} An express app which can be served with `app.get`
  */
 export function makeApp(options: AppOptions): PolyserveApplication {
-  const root = options.root;
+  const root = path.resolve(options.root);
   const baseComponentDir = options.componentDir;
   const componentDir = path.resolve(root, baseComponentDir);
   const packageName = options.packageName;
@@ -92,25 +92,25 @@ export function makeApp(options: AppOptions): PolyserveApplication {
     // _file_ path plus a leading slash, not the URL. :(
     // https://github.com/pillarjs/send/issues/132
     _send
-        .on('directory',
-            () => {
-              res.statusCode = 301;
-              res.setHeader('Location', req.originalUrl + '/');
-              res.end('Redirecting to ' + req.originalUrl + '/');
-            })
-        .on('error',
-            (err) => {
-              // A RequireJS found in the user's components directory will win
-              // over our verison.
-              if (err.statusCode === 404 &&
-                  err.path.endsWith('/requirejs/require.js')) {
-                send(req, localRequirePath).pipe(res);
-              } else {
-                res.statusCode = err.statusCode;
-                res.end(err.Error);
-              }
-            })
-        .pipe(res);
+      .on('directory',
+      () => {
+        res.statusCode = 301;
+        res.setHeader('Location', req.originalUrl + '/');
+        res.end('Redirecting to ' + req.originalUrl + '/');
+      })
+      .on('error',
+      (err) => {
+        // A RequireJS found in the user's components directory will win
+        // over our verison.
+        if (err.statusCode === 404 &&
+          err.path.endsWith('/requirejs/require.js')) {
+          send(req, localRequirePath).pipe(res);
+        } else {
+          res.statusCode = err.statusCode;
+          res.end(err.Error);
+        }
+      })
+      .pipe(res);
   });
   app.packageName = packageName;
   return app;

--- a/src/test/make_app_test.ts
+++ b/src/test/make_app_test.ts
@@ -12,11 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { assert } from 'chai';
+import {assert} from 'chai';
 import * as path from 'path';
 import * as supertest from 'supertest';
 
-import { makeApp } from '../make_app';
+import {makeApp} from '../make_app';
 
 const root = path.join(__dirname, '..', '..', 'test');
 const componentDir = path.join(root, 'components');
@@ -25,23 +25,23 @@ const packageName = 'polyserve-test';
 suite('makeApp', () => {
 
   test('returns an app', () => {
-    let app = makeApp({ root, componentDir, packageName });
+    let app = makeApp({root, componentDir, packageName});
     assert.isOk(app);
     assert.equal(app.packageName, 'polyserve-test');
   });
 
   test('serves package files', async () => {
-    let app = makeApp({ root, componentDir, packageName });
+    let app = makeApp({root, componentDir, packageName});
     await supertest(app)
-      .get('/polyserve-test/test-file.txt')
-      .expect(200, 'PASS\n');
+        .get('/polyserve-test/test-file.txt')
+        .expect(200, 'PASS\n');
   });
 
   test('supports relative roots', async () => {
-    let app = makeApp({ root: './test', componentDir, packageName });
+    let app = makeApp({root: './test', componentDir, packageName});
     await supertest(app)
-      .get('/polyserve-test/test-file.txt')
-      .expect(200, 'PASS\n');
+        .get('/polyserve-test/test-file.txt')
+        .expect(200, 'PASS\n');
   });
 
   test('serves component files', async () => {
@@ -51,8 +51,8 @@ suite('makeApp', () => {
       packageName,
     });
     await supertest(app)
-      .get('/test-component/test-file.txt')
-      .expect(200, 'TEST COMPONENT\n');
+        .get('/test-component/test-file.txt')
+        .expect(200, 'TEST COMPONENT\n');
   });
 
   test('serves component indices', async () => {
@@ -71,9 +71,9 @@ suite('makeApp', () => {
       packageName,
     });
     await supertest(app)
-      .get('/test-component')
-      .expect(301)
-      .expect('Location', '/test-component/');
+        .get('/test-component')
+        .expect(301)
+        .expect('Location', '/test-component/');
   });
 
   test('serves scoped package files', async () => {
@@ -83,8 +83,8 @@ suite('makeApp', () => {
       packageName: '@polymer/polyserve-test',
     });
     await supertest(app)
-      .get('/@polymer/polyserve-test/test-file.txt')
-      .expect(200, 'PASS\n');
+        .get('/@polymer/polyserve-test/test-file.txt')
+        .expect(200, 'PASS\n');
   });
 
   test('serves scoped component files', async () => {
@@ -94,8 +94,8 @@ suite('makeApp', () => {
       packageName: '@polymer/polyserve-test',
     });
     await supertest(app)
-      .get('/@polymer/test-component/test-file.txt')
-      .expect(200, 'TEST COMPONENT\n');
+        .get('/@polymer/test-component/test-file.txt')
+        .expect(200, 'TEST COMPONENT\n');
   });
 
 });

--- a/src/test/make_app_test.ts
+++ b/src/test/make_app_test.ts
@@ -12,11 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {assert} from 'chai';
+import { assert } from 'chai';
 import * as path from 'path';
 import * as supertest from 'supertest';
 
-import {makeApp} from '../make_app';
+import { makeApp } from '../make_app';
 
 const root = path.join(__dirname, '..', '..', 'test');
 const componentDir = path.join(root, 'components');
@@ -25,16 +25,23 @@ const packageName = 'polyserve-test';
 suite('makeApp', () => {
 
   test('returns an app', () => {
-    let app = makeApp({root, componentDir, packageName});
+    let app = makeApp({ root, componentDir, packageName });
     assert.isOk(app);
     assert.equal(app.packageName, 'polyserve-test');
   });
 
   test('serves package files', async () => {
-    let app = makeApp({root, componentDir, packageName});
+    let app = makeApp({ root, componentDir, packageName });
     await supertest(app)
-        .get('/polyserve-test/test-file.txt')
-        .expect(200, 'PASS\n');
+      .get('/polyserve-test/test-file.txt')
+      .expect(200, 'PASS\n');
+  });
+
+  test('supports relative roots', async () => {
+    let app = makeApp({ root: './test', componentDir, packageName });
+    await supertest(app)
+      .get('/polyserve-test/test-file.txt')
+      .expect(200, 'PASS\n');
   });
 
   test('serves component files', async () => {
@@ -44,8 +51,8 @@ suite('makeApp', () => {
       packageName,
     });
     await supertest(app)
-        .get('/test-component/test-file.txt')
-        .expect(200, 'TEST COMPONENT\n');
+      .get('/test-component/test-file.txt')
+      .expect(200, 'TEST COMPONENT\n');
   });
 
   test('serves component indices', async () => {
@@ -64,9 +71,9 @@ suite('makeApp', () => {
       packageName,
     });
     await supertest(app)
-        .get('/test-component')
-        .expect(301)
-        .expect('Location', '/test-component/');
+      .get('/test-component')
+      .expect(301)
+      .expect('Location', '/test-component/');
   });
 
   test('serves scoped package files', async () => {
@@ -76,8 +83,8 @@ suite('makeApp', () => {
       packageName: '@polymer/polyserve-test',
     });
     await supertest(app)
-        .get('/@polymer/polyserve-test/test-file.txt')
-        .expect(200, 'PASS\n');
+      .get('/@polymer/polyserve-test/test-file.txt')
+      .expect(200, 'PASS\n');
   });
 
   test('serves scoped component files', async () => {
@@ -87,8 +94,8 @@ suite('makeApp', () => {
       packageName: '@polymer/polyserve-test',
     });
     await supertest(app)
-        .get('/@polymer/test-component/test-file.txt')
-        .expect(200, 'TEST COMPONENT\n');
+      .get('/@polymer/test-component/test-file.txt')
+      .expect(200, 'TEST COMPONENT\n');
   });
 
 });


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

This allows for configurations like:

```ts
polyserve.makeApp({
  packageName: 'foo-bar',
  root: '../client',
})
```
