### PR TITLE
Fix specifier rewriting when given a relative componentDir setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 
+* Fix import specifier rewriting when given a relative componentDir.
+
 ## [0.25.0](https://github.com/PolymerLabs/polyserve/tree/0.25.0) (2018-03-20)
 
 * Module bare specifier rewriting Babel plugin now works on Windows, does not rewrite fully qualified URLs, and will follow the "module" or "jsnext:main" fields when a package.json uses them instead of "main".

--- a/package-lock.json
+++ b/package-lock.json
@@ -5733,7 +5733,7 @@
     },
     "supertest": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/supertest/-/supertest-2.0.1.tgz",
       "integrity": "sha1-oFgIHXiPFRXUcA11Aogea3WeRM0=",
       "dev": true,
       "requires": {

--- a/src/compile-middleware.ts
+++ b/src/compile-middleware.ts
@@ -114,6 +114,9 @@ export function babelCompile(
         return cached;
       }
 
+      // Make sure that componentDir is absolute, like jsTransform expects
+      componentDir = path.resolve(rootDir, componentDir);
+
       let transformed;
       const contentType = getContentType(response);
       let requestPath = request.path;
@@ -151,6 +154,8 @@ export function babelCompile(
             isComponentRequest,
             componentUrl,
             moduleResolution,
+            componentDir,
+            rootDir,
             options);
       } else if (javaScriptMimeTypes.includes(contentType)) {
         transformed = jsTransform(body, {
@@ -178,6 +183,8 @@ function compileHtml(
     isComponentRequest: boolean,
     componentUrl: string,
     moduleResolution: 'none'|'node',
+    componentDir: string,
+    rootDir: string,
     options: CompileOptions): string {
   const document = parse5.parse(source);
   let requireScriptTag, wctScriptTag;
@@ -235,6 +242,8 @@ function compileHtml(
           moduleResolution,
           filePath,
           isComponentRequest,
+          componentDir,
+          rootDir,
         });
       } catch (e) {
         // Continue so that we leave the original script as-is. It might

--- a/src/test/compile-middleware_test.ts
+++ b/src/test/compile-middleware_test.ts
@@ -261,7 +261,7 @@ suite('compile-middleware', () => {
         root: path.join(root, 'npm-package'),
         compile: 'never',
         moduleResolution: 'node',
-        componentDir: path.join(root, 'npm-package/node_modules'),
+        componentDir: 'node_modules',
         packageName: 'an-npm-package',
       });
       babelCompileCache.reset();
@@ -276,16 +276,24 @@ suite('compile-middleware', () => {
 
     suite('root package', () => {
 
-      test(
-          'root package bare specifiers in scoped component requests',
-          async () => {
-            await assertGolden(
-                '/components/an-npm-package/npm-module.js',
-                'golden/npm-package/npm-module.js');
-          });
+      test('bare specifiers in scoped component requests', async () => {
+        await assertGolden(
+            '/components/an-npm-package/npm-module.js',
+            'golden/npm-package/npm-module.js');
+      });
 
-      test('root package bare specifiers in app requests', async () => {
+      test('bare specifiers in scoped component HTML requests', async () => {
+        await assertGolden(
+            '/components/an-npm-package/component.html',
+            'golden/npm-package/component.html');
+      });
+
+      test('bare specifiers in app requests', async () => {
         await assertGolden('/app.js', 'golden/npm-package/app.js');
+      });
+
+      test('bare specifiers in app HTML requests', async () => {
+        await assertGolden('/index.html', 'golden/npm-package/index.html');
       });
 
     });

--- a/test/golden/npm-package/component.html
+++ b/test/golden/npm-package/component.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><html><head>
+    <script type="module">
+import * as test from '../test-dependency/dep.js';</script>
+  </head>
+<body>
+</body></html>

--- a/test/golden/npm-package/index.html
+++ b/test/golden/npm-package/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><html><head>
+    <script type="module">
+import * as test from './node_modules/test-dependency/dep.js';</script>
+  </head>
+<body>
+</body></html>

--- a/test/npm-package/component.html
+++ b/test/npm-package/component.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <script type="module">
+      import * as test from 'test-dependency';
+    </script>
+  </head>
+</html>

--- a/test/npm-package/index.html
+++ b/test/npm-package/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <script type="module">
+      import * as test from 'test-dependency';
+    </script>
+  </head>
+</html>


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

The reason why tests didn't pick this up is that the tests passed an absolute componentDir path. This change makes things work with relative and absolute paths, changes the tests to pass a relative path like the CLI does, and also adds tests for HTML.